### PR TITLE
fix: the incorrect comment being inserted for JSX in certain circumstances

### DIFF
--- a/src/lib/__tests__/suppressTsErrors.test.ts
+++ b/src/lib/__tests__/suppressTsErrors.test.ts
@@ -177,6 +177,67 @@ describe("suppressTsErrors", () => {
     },
     {
       text: `
+        import * as React from "react";
+        class Bar extends React.Component<{msg: string}> {
+          render() {
+            return <span>Bar</span>;
+          }
+        }
+        class Baz extends React.Component<{msg: number}> {
+          render() {
+            return <span>Baz</span>;
+          }
+        }
+        const Foo = (props: {bar: React.ReactElement<React.ComponentProps<typeof Bar>>}) => <div>{props.bar}</div>;
+        function tsxFunc() {
+          return (
+            <div>
+              <Foo
+                bar={
+                  <Baz msg="Hello">
+                    World
+                  </Baz>
+                }
+              />
+            </div>
+          );
+        }
+      `,
+      fileName: "target.tsx",
+      commentType: 1,
+      withErrorCode: true,
+      expectedText: `
+        import * as React from "react";
+        class Bar extends React.Component<{msg: string}> {
+          render() {
+            return <span>Bar</span>;
+          }
+        }
+        class Baz extends React.Component<{msg: number}> {
+          render() {
+            return <span>Baz</span>;
+          }
+        }
+        const Foo = (props: {bar: React.ReactElement<React.ComponentProps<typeof Bar>>}) => <div>{props.bar}</div>;
+        function tsxFunc() {
+          return (
+            <div>
+              <Foo
+                bar={
+                  // @ts-expect-error TS2769
+                  <Baz msg="Hello">
+                    World
+                  </Baz>
+                }
+              />
+            </div>
+          );
+        }
+      `,
+      expectedCommentCount: 1,
+    },
+    {
+      text: `
         const a: number = 1;
       `,
       fileName: "target.ts",

--- a/src/lib/buildComment.ts
+++ b/src/lib/buildComment.ts
@@ -22,7 +22,12 @@ function isSomKindOfJsxAtLine(
 
   const isJsxStartOpeningElement =
     targetNode?.getPreviousSibling()?.getKind() ===
-    ts.SyntaxKind.OpenParenToken;
+      ts.SyntaxKind.OpenParenToken ||
+    // This can happen when the error is on the opening JSX tag inside
+    // a JSX expression when a block of JSX is being passed as a prop.
+    targetNode?.getPreviousSibling()?.getKind() ===
+      ts.SyntaxKind.OpenBraceToken;
+
   const isInnerJsxElement =
     targetNode?.getPreviousSibling()?.getKind() ===
     ts.SyntaxKind.JsxOpeningElement;


### PR DESCRIPTION
#28 missed an edge case where there's an error than needs suppressing on a JSX element that's immediately inside a `{}`.  This usually happens when passing a block of JSX as a prop to another component.