### PR TITLE
handle fragments

### DIFF
--- a/src/lib/__tests__/buildComment.spec.ts
+++ b/src/lib/__tests__/buildComment.spec.ts
@@ -132,6 +132,23 @@ describe("buildComment", () => {
       `,
       lineNumber: 5,
       expected: "            // @ts-expect-error TS2322",
+    }, {
+      ...baseParam,
+      fileName: "target.tsx",
+      source: `
+function tsxFunc(num: number) {
+  return (
+    <div>
+      {overlap > 0 && (<>
+        <div>foo</div>
+        <div>{num.map(n => n)}</div>
+      </>)}
+    </div>
+  )
+}
+`,
+      lineNumber: 6,
+      expected: "        {/*\n         // @ts-expect-error TS2322 */}",
     },
   ])(
     "build comment",

--- a/src/lib/__tests__/buildComment.spec.ts
+++ b/src/lib/__tests__/buildComment.spec.ts
@@ -132,7 +132,8 @@ describe("buildComment", () => {
       `,
       lineNumber: 5,
       expected: "            // @ts-expect-error TS2322",
-    }, {
+    },
+    {
       ...baseParam,
       fileName: "target.tsx",
       source: `

--- a/src/lib/buildComment.ts
+++ b/src/lib/buildComment.ts
@@ -30,7 +30,8 @@ function isSomKindOfJsxAtLine(
 
   const isInnerJsxElement =
     targetNode?.getPreviousSibling()?.getKind() ===
-    ts.SyntaxKind.JsxOpeningElement;
+    ts.SyntaxKind.JsxOpeningElement || targetNode?.getPreviousSibling()?.getKind() ===
+    ts.SyntaxKind.JsxOpeningFragment;
   const isJsxElement = [
     ts.SyntaxKind.JsxText,
     ts.SyntaxKind.JsxTextAllWhiteSpaces,


### PR DESCRIPTION
I noticed an error when running this tool:

Input:

```tsx
function tsxFunc(num: number) {
  return (
    <div>
      {(<>
        <div>foo</div>
        <div>{num.map(n => n)}</div>
      </>)}
    </div>
  )
}
```

Output (error on line 5):

```tsx
function tsxFunc(num: number) {
  return (
    <div>
      {(<>
        // @ts-expect-error TS232
        <div>foo</div>
        <div>{num.map(n => n)}</div>
      </>)}
    </div>
  )
}
```


With this PR:


Output (error on line 5):

```tsx
function tsxFunc(num: number) {
  return (
    <div>
      {(<>
        {/*
        // @ts-expect-error TS2322 */}
        <div>foo</div>
        <div>{num.map(n => n)}</div>
      </>)}
    </div>
  )
}
```