### PR TITLE
fix: add error handling for tsHandler

### DIFF
--- a/src/handlers/tsHandler.ts
+++ b/src/handlers/tsHandler.ts
@@ -15,24 +15,38 @@ export const tsHandler = ({
   const progressBar = generateProgressBar();
   progressBar.start(sourceFiles.length, 0);
 
+  // Store files that threw an error
+  const failedFileArr = [];
+
   // Rewrite source in ts/tsx file with source with comment
   let insertedCommentCount = 0;
   for (const sourceFile of sourceFiles) {
-    const { text: textWithComment, count: insertedCommentCountPerFile } =
-      suppressTsErrors({
-        sourceFile,
-        commentType,
-        withErrorCode: errorCode,
-      });
+    try {
+      const { text: textWithComment, count: insertedCommentCountPerFile } =
+        suppressTsErrors({
+          sourceFile,
+          commentType,
+          withErrorCode: errorCode,
+        });
 
-    if (insertedCommentCountPerFile > 0) {
-      sourceFile.replaceWithText(textWithComment);
-      sourceFile.saveSync();
-      insertedCommentCount += insertedCommentCountPerFile;
+      if (insertedCommentCountPerFile > 0) {
+        sourceFile.replaceWithText(textWithComment);
+        sourceFile.saveSync();
+        insertedCommentCount += insertedCommentCountPerFile;
+      }
+      progressBar.increment();
+    } catch {
+      failedFileArr.push(sourceFile.getFilePath());
     }
-    progressBar.increment();
   }
 
   progressBar.stop();
+
+  if (failedFileArr.length > 0)
+    console.log(
+      "There were issues handling the following files:",
+      failedFileArr,
+      "Please review source files before re-running script",
+    );
   return insertedCommentCount;
 };


### PR DESCRIPTION
I often ran into this error:
<img width="922" alt="Screenshot 2025-02-04 at 5 29 38 PM" src="https://github.com/user-attachments/assets/76fd87ad-0265-46f5-b156-c968735b3a48" />

At first, I thought it was an issue with it being passed too many files (which is what led me to wanting something like https://github.com/kawamataryo/suppress-ts-errors/pull/644), but I found that this still happened even when single problematic files were being passed. I found that sometimes the error stemmed from a syntax error in the source file, but other times it wasn't immediately obvious what was wrong. Either way, I think a better experience is to catch the error and continue processing the rest of the source files (and provide a list of the bad files for further debugging).