### PR TITLE
fix: update jsx comment formatting

### DIFF
--- a/src/lib/buildComment.ts
+++ b/src/lib/buildComment.ts
@@ -74,9 +74,9 @@ export const buildComment = ({
   );
   sourceFile;
   return isSomKindOfJsxAtLine(sourceFile, lineNumber)
-    ? `${" ".repeat(whiteSpaceCount)}{/*\n${" ".repeat(
-        whiteSpaceCount + 1,
-      )}// ${comment}${withErrorCode ? ` TS${errorCode}` : ""} */}`
+    ? `${" ".repeat(whiteSpaceCount)}{/* ${comment}${
+        withErrorCode ? ` TS${errorCode}` : ""
+      } */}`
     : `${" ".repeat(whiteSpaceCount)}// ${comment}${
         withErrorCode ? ` TS${errorCode}` : ""
       }`;


### PR DESCRIPTION
Sorry, one last PR!

For more context, I'm planning on using your script in conjunction with my own script that deletes all lines with `@ts-expect-error`comments in an effort to trim down unused directives (that break on compile)

This one is more of a pet peeve fix than anything. When inserting comments into JSX, I think it would be cleaner to insert it in a single line (and it'll make it easier for my script to catch and delete these comments without creating syntax errors).

Definitely a lower priority and not as necessary IMO if you disagree with this